### PR TITLE
Set command timeout to 60 minutes in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,7 @@ jobs:
           host: ${{ secrets.STAGING_SERVER_HOST }}
           username: ${{ secrets.STAGING_SERVER_USER }}
           key: ${{ secrets.STAGING_SERVER_SSH_KEY }}
+          command_timeout: 60m
           script: |
             cd /opt/messenger/Messenger-ALYOsha/
             


### PR DESCRIPTION
Increase command timeout for deployment script.